### PR TITLE
WIP ci: Move to IT managed AWS self-hosted runners 

### DIFF
--- a/.github/workflows/build-check-sdk.yaml
+++ b/.github/workflows/build-check-sdk.yaml
@@ -50,7 +50,7 @@ jobs:
 
   build:
     needs: generate-matrix
-    runs-on: ["self-hosted", "qcom-u2404", "amd64"]
+    runs-on: [self-hosted, qcom-u2404, amd64]
     timeout-minutes: 720
     strategy:
       fail-fast: false


### PR DESCRIPTION
These runners should be equivalent to the currently used in GCP.

IT provides two types of runners that are just like what is been used in
in GCP:

 * `runs-on: [self-hosted, qcom-u2404, amd64-dev]`
 * `runs-on: [self-hosted, qcom-u2404, arm64-dev]`

Signed-off-by: Satish Mhaske <smhaskey@qti.qualcomm.com>