### PR TITLE
docs: remove RB3 Gen2 references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <div align="center">
   <h1>QRB ROS IMU</h1>
   <p align="center">
-    <img src="https://s7d1.scene7.com/is/image/dmqualcommprod/rb3gen2-dev-kits-hero-7" alt="Qualcomm QRB ROS" title="Qualcomm QRB ROS" />
   </p>
   <p>ROS Packages for IMU Hardware on Qualcomm Robotics Platforms</p>
 
@@ -125,11 +124,9 @@ The `ISession Framework` provides the foundation for sensor data collecting on Q
 <table >
   <tr>
     <th>Development Hardware</th>
-    <td>Qualcomm Dragonwing™ RB3 Gen2</td>
   </tr>
   <tr>
     <th>Hardware Overview</th>
-    <th><a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"><img src="https://s7d1.scene7.com/is/image/dmqualcommprod/rb3-gen2-carousel?fmt=webp-alpha&qlt=85" width="180"/></a></th>
   </tr>
   <tr>
     <th>IMU Hardware</th>


### PR DESCRIPTION
## Summary
- Remove RB3 Gen2 references from the README, since RB3 Gen2 is no longer a supported target.

## Details
Removes RB3 Gen2 references from the README (supported-hardware table entry, and any RB3-specific banner image), keeping IQ-9075 EVK as the reference hardware. Documentation-only change.